### PR TITLE
Namespace CRS element when used in Filter List

### DIFF
--- a/soap/index.js
+++ b/soap/index.js
@@ -38,7 +38,7 @@ class DepartureBoardSoap {
           let val="";
           if(key == "filterList"){
               options[key].forEach((crs) => {
-                  val += `<crs>${crs}</crs>`;
+                  val += `<ldb:crs>${crs}</ldb:crs>`;
               });
           } else {
               val = `${options[key]}`                


### PR DESCRIPTION
First of all, thank you for working on this incredibly useful library!

I was finding my `GetNextDepartures` (& other similar) requests were failing because the `crs` child elements in the filter list weren't being namespaced.  This PR corrects it.

Note I've only tested this with the public API (are there any requests on the staff API that use `filterList`?)